### PR TITLE
Removed shared_vpc variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,25 +36,19 @@ Truefoundry Google Cloud Network Module
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster | `string` | n/a | yes |
 | <a name="input_enable_flow_logs"></a> [enable\_flow\_logs](#input\_enable\_flow\_logs) | Enable flow logs for subnets | `bool` | `false` | no |
 | <a name="input_enable_private_access"></a> [enable\_private\_access](#input\_enable\_private\_access) | Private access for subnets | `bool` | `true` | no |
-| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | SHIM: network name. Should be supplied if shim is true. | `string` | `""` | no |
+| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | ID of the existing network. Only used when use\_existing\_network is set to true | `string` | `""` | no |
 | <a name="input_network_vpc_secondary_ranges"></a> [network\_vpc\_secondary\_ranges](#input\_network\_vpc\_secondary\_ranges) | List of secondary ranges | <pre>list(object({<br/>    range_name    = string<br/>    ip_cidr_range = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_private_subnet_cidr"></a> [private\_subnet\_cidr](#input\_private\_subnet\_cidr) | CIDR range for private subnet | `string` | `""` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID in which clusters are deployed | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | Region to deploy your cluster in | `string` | n/a | yes |
 | <a name="input_routing_mode"></a> [routing\_mode](#input\_routing\_mode) | Routing mode for the network | `string` | `"GLOBAL"` | no |
-| <a name="input_shared_vpc"></a> [shared\_vpc](#input\_shared\_vpc) | If true, the shim network is a shared VPC | `bool` | `false` | no |
-| <a name="input_shared_vpc_host_project"></a> [shared\_vpc\_host\_project](#input\_shared\_vpc\_host\_project) | Shared VPC: Project ID of the host project. Should be supplied if shared\_vpc is true. | `string` | `""` | no |
-| <a name="input_shared_vpc_network_name"></a> [shared\_vpc\_network\_name](#input\_shared\_vpc\_network\_name) | Shared VPC: Network name. Should be supplied if shared\_vpc is true. | `string` | `""` | no |
-| <a name="input_shared_vpc_subnet_name"></a> [shared\_vpc\_subnet\_name](#input\_shared\_vpc\_subnet\_name) | Shared VPC: Subnet name. Should be supplied if shared\_vpc is true. | `string` | `""` | no |
-| <a name="input_shim"></a> [shim](#input\_shim) | If true will not create the network and forward the input values to the same outputs. | `bool` | `false` | no |
-| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | SHIM: Subnetwork ID. Should be supplied if shim is true. | `string` | `""` | no |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | ID of the existing subnet. Only used when use\_existing\_network is set to true | `string` | `""` | no |
+| <a name="input_use_existing_network"></a> [use\_existing\_network](#input\_use\_existing\_network) | If true will not create the network and forward the input values to the same outputs. | `bool` | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_additional_secondary_ranges"></a> [additional\_secondary\_ranges](#output\_additional\_secondary\_ranges) | Additional secondary ranges applied to the subnet |
 | <a name="output_network_id"></a> [network\_id](#output\_network\_id) | ID of the network |
-| <a name="output_network_name"></a> [network\_name](#output\_network\_name) | Name of the network |
 | <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | ID of the subnet |
 <!-- END_TF_DOCS -->

--- a/gcn.tf
+++ b/gcn.tf
@@ -1,7 +1,7 @@
 # # Create a VPC network
 
 module "network" {
-  count                   = var.shim || var.shared_vpc ? 0 : 1
+  count                   = var.use_existing_network ? 0 : 1
   source                  = "terraform-google-modules/network/google"
   version                 = "9.3.0"
   description             = "Truefoundry network for ${var.cluster_name}"
@@ -76,13 +76,13 @@ module "network" {
 }
 
 resource "time_sleep" "wait_2_mins" {
-  count      = var.shim || var.shared_vpc ? 0 : 1
+  count      = var.use_existing_network ? 0 : 1
   depends_on = [module.network[0]]
 
   create_duration = "2m"
 }
 module "cloud_router" {
-  count       = var.shim || var.shared_vpc ? 0 : 1
+  count       = var.use_existing_network ? 0 : 1
   source      = "terraform-google-modules/cloud-router/google"
   version     = "6.2.0"
   description = "Truefoundry NAT router for ${var.cluster_name}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,19 +1,9 @@
-output "network_name" {
-  value       = var.shim || var.shared_vpc ? var.shared_vpc ? var.shared_vpc_network_name : var.network_name : module.network[0].network_name
-  description = "Name of the network"
-}
-
 output "network_id" {
-  value       = var.shim || var.shared_vpc ? var.shared_vpc ? "projects/${var.shared_vpc_host_project}/global/networks/${var.shared_vpc_network_name}" : "projects/${var.project_id}/global/networks/${var.network_name}" : module.network[0].network_id
+  value       = var.use_existing_network ? var.network_id  : module.network[0].network_id
   description = "ID of the network"
 }
 
 output "subnet_id" {
-  value       = var.shim || var.shared_vpc ? var.shared_vpc ? "projects/${var.shared_vpc_host_project}/regions/${var.region}/subnetworks/${var.shared_vpc_subnet_name}" : var.subnet_id : module.network[0].subnets_ids[0]
+  value       = var.use_existing_network ? var.subnet_id : module.network[0].subnets_ids[0]
   description = "ID of the subnet"
-}
-
-output "additional_secondary_ranges" {
-  value       = var.shim || var.shared_vpc ? var.shared_vpc ? [] : [] : module.network[0].subnets_secondary_ranges
-  description = "Additional secondary ranges applied to the subnet"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "network_id" {
-  value       = var.use_existing_network ? var.network_id  : module.network[0].network_id
+  value       = var.use_existing_network ? var.network_id : module.network[0].network_id
   description = "ID of the network"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -23,14 +23,9 @@ variable "cluster_name" {
 ################################################################################
 # Network
 ################################################################################
-variable "shim" {
-  description = "If true will not create the network and forward the input values to the same outputs."
-  type        = bool
-  default     = false
-}
 
-variable "shared_vpc" {
-  description = "If true, the shim network is a shared VPC"
+variable "use_existing_network" {
+  description = "If true will not create the network and forward the input values to the same outputs."
   type        = bool
   default     = false
 }
@@ -38,39 +33,18 @@ variable "shared_vpc" {
 ################################################################################
 # Network SHIM
 ################################################################################
-variable "network_name" {
-  description = "SHIM: network name. Should be supplied if shim is true."
+variable "network_id" {
+  description = "ID of the existing network. Only used when use_existing_network is set to true"
   type        = string
   default     = ""
 }
 
 variable "subnet_id" {
-  description = "SHIM: Subnetwork ID. Should be supplied if shim is true."
+  description = "ID of the existing subnet. Only used when use_existing_network is set to true"
   type        = string
   default     = ""
 }
 
-################################################################################
-# Shared VPC
-################################################################################
-
-variable "shared_vpc_host_project" {
-  description = "Shared VPC: Project ID of the host project. Should be supplied if shared_vpc is true."
-  type        = string
-  default     = ""
-}
-
-variable "shared_vpc_network_name" {
-  description = "Shared VPC: Network name. Should be supplied if shared_vpc is true."
-  type        = string
-  default     = ""
-}
-
-variable "shared_vpc_subnet_name" {
-  description = "Shared VPC: Subnet name. Should be supplied if shared_vpc is true."
-  type        = string
-  default     = ""
-}
 ################################################################################
 # Network NON-SHIM
 ################################################################################


### PR DESCRIPTION
1. Removed shared_vpc variables
2. Added support for `subnet_id` and `network_id`
3. Moved `shim` to `use_existing_network`